### PR TITLE
Meet alphanumeric requirement

### DIFF
--- a/Shorty.Tests/Services/EncodingServiceTests.cs
+++ b/Shorty.Tests/Services/EncodingServiceTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Text.RegularExpressions;
+using FluentAssertions;
+using Shorty.Services;
+
+namespace Shorty.Tests.Services
+{
+    public class EncodingServiceTests
+    {
+        [Fact]
+        public void TestCreateUrlTag_Alpha()
+        {
+            var expectedResult = "AHKUAaAOeX2F5q4a5B6rGw";
+            var guid = new Guid("01947200-0ea0-7d79-85e6-ae1ae41eab1b");
+            var testService = new EncodingService(MockKeyProvider(guid.ToByteArray()));
+            var result = testService.CreateUrlTag();
+
+            result.Should().Be(expectedResult);
+        }
+
+        [Fact]
+        public void TestCreateUrlTag_NonAlpha()
+        {
+            var matchRegex = new Regex("[A-Z]{2}XGUAbcKlHajIGgN[a-z]{2}pDH7w");
+            var guid = new Guid("019471f9-0ab7-7694-a320-680dfe90c7ef");
+            var testService = new EncodingService(MockKeyProvider(guid.ToByteArray()));
+            var result = testService.CreateUrlTag();
+
+            matchRegex.IsMatch(result).Should().BeTrue();
+        }
+
+        private static Func<byte[]> MockKeyProvider(byte[] result)
+        {
+            return new Func<byte[]>(() => result);
+        }
+    }
+}

--- a/Shorty.Tests/Services/UrlServiceTests.cs
+++ b/Shorty.Tests/Services/UrlServiceTests.cs
@@ -16,7 +16,7 @@ namespace Shorty.Tests.Services
         [Fact]
         public async Task TestExpandUrl_BadUrl()
         {
-            var testService = new UrlService(MockConfig(), MockDataService().Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), MockDataService().Object, MockEncodingService());
             await Assert.ThrowsAsync<InvalidUrlException>(async () => await testService.ExpandUrl(badUrl));
         }
 
@@ -25,7 +25,7 @@ namespace Shorty.Tests.Services
         {
             var shortUrl = String.Concat(baseUrl, tag);
             var mockDataService = MockDataService(null, GetUrlDocument(goodFullUrl, tag));
-            var testService = new UrlService(MockConfig(), mockDataService.Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), mockDataService.Object, MockEncodingService());
             var result = await testService.ExpandUrl(shortUrl);
 
             result.Should().Be(goodFullUrl);
@@ -35,7 +35,7 @@ namespace Shorty.Tests.Services
         public async Task TestExpandUrl_UnknownUrl()
         {
             var unknownUrl = String.Concat(baseUrl, "bogus_tag");
-            var testService = new UrlService(MockConfig(), MockDataService().Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), MockDataService().Object, MockEncodingService());
             await Assert.ThrowsAsync<UnknownUrlException>(async () => await testService.ExpandUrl(unknownUrl));
         }
 
@@ -46,7 +46,7 @@ namespace Shorty.Tests.Services
         [Fact]
         public async Task TestShortenUrl_BadUrl()
         {
-            var testService = new UrlService(MockConfig(), MockDataService().Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), MockDataService().Object, MockEncodingService());
             await Assert.ThrowsAsync<InvalidUrlException>(async () => await testService.ShortenUrl(badUrl));
         }
 
@@ -56,7 +56,7 @@ namespace Shorty.Tests.Services
             var expectedUrl = String.Concat(baseUrl, tag);
             var saveValue = GetUrlDocument(goodFullUrl, tag);
             var mockDataService = MockDataService(null, null, saveValue);
-            var testService = new UrlService(MockConfig(), mockDataService.Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), mockDataService.Object, MockEncodingService());
             var result = await testService.ShortenUrl(goodFullUrl);
 
             result.Should().Be(expectedUrl);
@@ -69,7 +69,7 @@ namespace Shorty.Tests.Services
             var expectedUrl = String.Concat(baseUrl, tag);
             var findResult = GetUrlDocument(goodFullUrl, tag);
             var mockDataService = MockDataService(findResult);
-            var testService = new UrlService(MockConfig(), mockDataService.Object, MockKeyProvider());
+            var testService = new UrlService(MockConfig(), mockDataService.Object, MockEncodingService());
             var result = await testService.ShortenUrl(goodFullUrl);
 
             result.Should().Be(expectedUrl);
@@ -97,9 +97,11 @@ namespace Shorty.Tests.Services
             return mock;
         }
 
-        private static Func<byte[]> MockKeyProvider(byte[]? result = null)
+        private static IEncodingService MockEncodingService()
         {
-            return new Func<byte[]>(() => result ?? key);
+            var mock = new Mock<IEncodingService>();
+            mock.Setup(m => m.CreateUrlTag()).Returns(tag);
+            return mock.Object;
         }
 
         private static UrlDocument GetUrlDocument(string fullUrl, string tag)

--- a/Shorty/Program.cs
+++ b/Shorty/Program.cs
@@ -24,6 +24,7 @@ namespace Shorty
             builder.Services.AddOpenApi();
             builder.Services.AddSwaggerGen();
             builder.Services.AddScoped<IDataService, DataService>();
+            builder.Services.AddScoped<IEncodingService, EncodingService>();
             builder.Services.AddScoped<IUrlService, UrlService>();
             builder.Services.AddScoped((service) => KeyProvider(service));
             builder.Services.AddSingleton(dataStore);

--- a/Shorty/Services/DataService.cs
+++ b/Shorty/Services/DataService.cs
@@ -1,5 +1,4 @@
-﻿using LiteDB;
-using LiteDB.Async;
+﻿using LiteDB.Async;
 using Shorty.Models;
 
 namespace Shorty.Services

--- a/Shorty/Services/EncodingService.cs
+++ b/Shorty/Services/EncodingService.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using System.Text.RegularExpressions;
+
+namespace Shorty.Services
+{
+    public class EncodingService : IEncodingService
+    {
+        private readonly Func<byte[]> keyProvider;
+        public EncodingService(Func<byte[]> keyProvider)
+        {
+            this.keyProvider = keyProvider;
+        }
+
+        public string CreateUrlTag()
+        {
+            // NOTE: Documentation is unclear whether the encode overload that accepts a byte array
+            //       suppresses padding and substitutes URL-friendly characters for / and +.
+            //       Playing with some data looks like it does.
+            var tag = Base64UrlEncoder.Encode(keyProvider());
+
+            return urlRegex.IsMatch(tag) ? string.Concat(ReplaceChars(tag)) : tag;
+        }
+
+        /// <summary>
+        /// Makes tag conform to the requirement that all characters are alphanumeric.
+        /// It replaces dashes with two of a random upper case character.
+        /// Underscores are replaced with two of a random lower case character.
+        /// </summary>
+        /// <param name="tag"></param>
+        /// <returns>An enumerable containing the original string with dashes and underscores replaced</returns>
+        public IEnumerable<char> ReplaceChars(string tag)
+        {
+            var random = new Random();
+            var dashStandIn = Convert.ToChar(random.Next(65, 90));
+            var underscoreStandIn = Convert.ToChar(random.Next(97, 122));
+
+            foreach (var c in tag.ToCharArray())
+            {
+                if (c == '-')
+                {
+                    yield return dashStandIn;
+                    yield return dashStandIn;
+                }
+                else if (c == '_')
+                {
+                    yield return underscoreStandIn;
+                    yield return underscoreStandIn;
+                }
+                else
+                    yield return c;
+            };
+        }
+
+        static protected Regex urlRegex = new Regex("[-_]");
+    }
+}

--- a/Shorty/Services/IEncodingService.cs
+++ b/Shorty/Services/IEncodingService.cs
@@ -1,0 +1,7 @@
+﻿namespace Shorty.Services
+{
+    public interface IEncodingService
+    {
+        string CreateUrlTag();
+    }
+}

--- a/Shorty/Services/UrlService.cs
+++ b/Shorty/Services/UrlService.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Shorty.Configs;
 using Shorty.Exceptions;
 using Shorty.Models;
@@ -10,13 +9,13 @@ namespace Shorty.Services
     {
         private readonly EncoderConfig config;
         private readonly IDataService dataService;
-        private readonly Func<byte[]> keyProvider;
+        private readonly IEncodingService encodingService;
 
-        public UrlService(IOptions<EncoderConfig> config, IDataService dataService, Func<byte[]> keyProvider)
+        public UrlService(IOptions<EncoderConfig> config, IDataService dataService, IEncodingService encodingService)
         {
             this.config = config.Value;
             this.dataService = dataService;
-            this.keyProvider = keyProvider;
+            this.encodingService = encodingService;
         }
 
         public async Task<string> ExpandUrl(string shortUrl)
@@ -70,19 +69,11 @@ namespace Shorty.Services
             var url = new UrlDocument()
             {
                 FullUrl = uri.ToString(),
-                Tag = CreateUrlTag()
+                Tag = encodingService.CreateUrlTag()
             };
 
             await dataService.SaveUrl(url);
             return url;
-        }
-
-        public string CreateUrlTag()
-        {
-            // NOTE: Documentation is unclear whether the encode overload that accepts a byte array
-            //       suppresses padding and substitutes URL-friendly characters for / and +.
-            //       Playing with some data looks like it does.
-            return Base64UrlEncoder.Encode(keyProvider());
         }
     }
 }

--- a/Shorty/Shorty.http
+++ b/Shorty/Shorty.http
@@ -1,6 +1,25 @@
 @Shorty_HostAddress = http://localhost:5016
 
-GET {{Shorty_HostAddress}}/weatherforecast/
-Accept: application/json
+POST {{Shorty_HostAddress}}/Url/ShortenUrl
+Content-Type: application/json
+"https://ferrets.com/toys/puzzles?item=Akr45"
+
+###
+
+POST {{Shorty_HostAddress}}/Url/ShortenUrl
+Content-Type: application/json
+"bad.url.com"
+
+###
+
+POST {{Shorty_HostAddress}}/Url/ExpandUrl
+Content-Type: application/json
+"https://shorty.com/G3KUATicBXurP2Pj"
+
+###
+
+POST {{Shorty_HostAddress}}/Url/ExpandUrl
+Content-Type: application/json
+"https://shorty.com/UNKNOWN"
 
 ###


### PR DESCRIPTION
- Refactored the URL tag encoding into its own service.
- Refactored the URL tag encoding logic to replace non-alphanumeric characters.
- Brought tests up to date with the changes.
- Modified the .http file with test cases for the API.